### PR TITLE
in preOnline context, Computer.channel == null 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/chromedriver/ComputerListenerImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/chromedriver/ComputerListenerImpl.java
@@ -5,7 +5,9 @@ import hudson.FilePath;
 import hudson.model.Computer;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
+import hudson.remoting.VirtualChannel;
 import hudson.slaves.ComputerListener;
+import hudson.util.RemotingDiagnostics;
 import jenkins.model.Jenkins;
 
 import javax.inject.Inject;
@@ -26,21 +28,21 @@ public class ComputerListenerImpl extends ComputerListener {
     @Override
     public void onOnline(Computer c, TaskListener listener) throws IOException, InterruptedException {
         if (c.getNode()== Jenkins.getInstance())    // work around the bug where master doesn't call preOnline method
-            process(c, c.getNode().getRootPath(), listener);
+            process(c, c.getChannel(), c.getNode().getRootPath(), listener);
     }
 
     @Override
     public void preOnline(Computer c, Channel channel, FilePath root, TaskListener listener) throws IOException, InterruptedException {
-        process(c, root,listener);
+        process(c, channel, root,listener);
     }
 
-    public void process(Computer c, FilePath root, TaskListener listener) throws IOException, InterruptedException {
+    public void process(Computer c, VirtualChannel channel, FilePath root, TaskListener listener) throws IOException, InterruptedException {
         try {
             FilePath remoteDir = root.child(INSTALL_DIR);
             if (!remoteDir.child("chromedriver").exists()) {
                 listener.getLogger().println("Installing chromedriver to "+remoteDir);
-                Map<Object,Object> props = c.getSystemProperties();
-                File zip = downloadable.resolve((String) props.get("os.name"), (String) props.get("sun.arch.data.model"),listener);
+                Map<Object,Object> props = RemotingDiagnostics.getSystemProperties(channel);
+                        File zip = downloadable.resolve((String) props.get("os.name"), (String) props.get("sun.arch.data.model"), listener);
                 remoteDir.mkdirs();
                 new FilePath(zip).unzip(remoteDir);
             }


### PR DESCRIPTION
called without a channel set, Computer#getSystemProperties (silently) fails and return "N/A"=>"N/A" map, so fail to resolve the "os.name" property.
