### PR TITLE
wrap attempt to update ENV with check for current computer

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/chromedriver/EnvironmentContributorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/chromedriver/EnvironmentContributorImpl.java
@@ -20,7 +20,9 @@ public class EnvironmentContributorImpl extends EnvironmentContributor {
     @Override
     public void buildEnvironmentFor(Run r, EnvVars envs, TaskListener listener) throws IOException, InterruptedException {
         Computer c = Computer.currentComputer();
-        FilePath path = c.getNode().getRootPath().child(ComputerListenerImpl.INSTALL_DIR);
-        envs.put("PATH+CHROMEDRIVER",path.getRemote());
+        if(c != null) {
+          FilePath path = c.getNode().getRootPath().child(ComputerListenerImpl.INSTALL_DIR);
+          envs.put("PATH+CHROMEDRIVER",path.getRemote());
+        }
     }
 }


### PR DESCRIPTION
I ra
since we can be invoked by Git Polling (at minimum) where currentComputer() is not
defined

I believe this will solve these issues:
https://issues.jenkins-ci.org/browse/JENKINS-26524
https://issues.jenkins-ci.org/browse/JENKINS-25911