### PR TITLE
[FIXED JENKINS-26524] Don't crash git SCM polling

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/chromedriver/EnvironmentContributorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/chromedriver/EnvironmentContributorImpl.java
@@ -9,6 +9,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 
 import java.io.IOException;
+import java.util.logging.Logger;
 
 /**
  * Modifies PATH to include chromedriver
@@ -17,9 +18,23 @@ import java.io.IOException;
  */
 @Extension
 public class EnvironmentContributorImpl extends EnvironmentContributor {
+    private static final Logger LOGGER = Logger.getLogger(EnvironmentContributorImpl.class.getName());
+
     @Override
     public void buildEnvironmentFor(Run r, EnvVars envs, TaskListener listener) throws IOException, InterruptedException {
         Computer c = Computer.currentComputer();
+        if (c == null) {
+        	// not an executor, so no need to populate environment
+        	return;
+        }
+        if (c.getNode() == null) {
+        	LOGGER.warning("Build node for computer is gone!");
+        	return;
+        }
+        if (c.getNode().getRootPath() == null) {
+        	LOGGER.warning("Build node is online, failed to resolve root path!");
+        	return;
+        }
         FilePath path = c.getNode().getRootPath().child(ComputerListenerImpl.INSTALL_DIR);
         envs.put("PATH+CHROMEDRIVER",path.getRemote());
     }


### PR DESCRIPTION
When the chrome driver is installed and SCM polling is enabled on a project, then when git does the polling the system calls the chromedriver `EnvironmentContributor` which crashes. See stack trace:

~~~
Failed to record SCM polling for hudson.model.FreeStyleProject@3114d18c[spritifier]
java.lang.NullPointerException
	at org.jenkinsci.plugins.chromedriver.EnvironmentContributorImpl.buildEnvironmentFor(EnvironmentContributorImpl.java:23)
	at hudson.model.Run.getEnvironment(Run.java:2248)
	at hudson.model.AbstractBuild.getEnvironment(AbstractBuild.java:935)
	at hudson.plugins.git.GitSCM.compareRemoteRevisionWithImpl(GitSCM.java:564)
	at hudson.plugins.git.GitSCM.compareRemoteRevisionWith(GitSCM.java:526)
	at hudson.scm.SCM.compareRemoteRevisionWith(SCM.java:381)
	at hudson.scm.SCM.poll(SCM.java:398)
	at hudson.model.AbstractProject._poll(AbstractProject.java:1459)
	at hudson.model.AbstractProject.poll(AbstractProject.java:1362)
	at hudson.triggers.SCMTrigger$Runner.runPolling(SCMTrigger.java:510)
	at hudson.triggers.SCMTrigger$Runner.run(SCMTrigger.java:539)
	at hudson.util.SequentialExecutionQueue$QueueEntry.run(SequentialExecutionQueue.java:118)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
~~~

The problem is that the `EnvironmentContributorImpl` doesn't handle error detection well when resolving the required path, and specifically doesn't take into consideration that getEnvironment is run for SCM polling on the master server, under which `Computer.currentComputer()` returns `null`.

This PR adds some needed error handling and prevents the crash.