### PR TITLE
Include architecture when fetching mac driver

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/chromedriver/DownloadableImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/chromedriver/DownloadableImpl.java
@@ -88,9 +88,14 @@ public class DownloadableImpl extends Downloadable {
     }
     
     private String getType(String osName, String sunArchDataModel) {
-        if (osName.contains("Mac") || osName.contains("Darwin"))
+        if (osName.contains("Mac") || osName.contains("Darwin")) {
+            if (sunArchDataModel.equals("32"))
+                return "mac32";
+            if (sunArchDataModel.equals("64"))
+                return "mac64";
             return "mac";
-
+        }
+        
         if (osName.contains("Windows"))
             return "win";
 


### PR DESCRIPTION
Trying to address error: **No matching binary found for type=mac**. The API specified here: https://github.com/jenkinsci/backend-crawler/blob/master/chromedriver.groovy#L6 seems to include architecture in download file